### PR TITLE
Added dep flag space to clang toolchain

### DIFF
--- a/lib/bake/toolchain/clang.rb
+++ b/lib/bake/toolchain/clang.rb
@@ -16,7 +16,8 @@ module Bake
       :OBJECT_FILE_FLAG => "-o",
       :OBJ_FLAG_SPACE => true,
       :COMPILE_FLAGS => "-c ",
-      :DEP_FLAGS => "-MD -MF ", # empty space at the end is important!
+      :DEP_FLAGS => "-MD -MF",
+      :DEP_FLAGS_SPACE => true,
       :ERROR_PARSER => gccCompilerErrorParser
     })
 


### PR DESCRIPTION
When using clang the depfile should be space seperated from the -MF
argument. This was formerly done with a ugly space in the DEP_ARGS.
By the meantime a additional flag does exctly what is needed.