### PR TITLE
Return 0 on success when creating a project

### DIFF
--- a/lib/bake/options/create.rb
+++ b/lib/bake/options/create.rb
@@ -88,7 +88,7 @@ module Bake
       end
 
       puts "Project created."
-      ExitHelper.exit(1)
+      ExitHelper.exit(0)
     end
 
   end


### PR DESCRIPTION
On success, bake  should return `0` upon successful project creation. This fixes #135. 