### PR TITLE
Allow gem dependencies to be in custom location

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bake-toolkit (2.37.5)
+    bake-toolkit (2.37.13)
       colored (= 1.2)
       concurrent-ruby (= 1.0.5)
       highline (= 1.7.8)
@@ -23,6 +23,7 @@ GEM
     docile (1.1.5)
     highline (1.7.8)
     json (2.1.0)
+    rake (12.0.0)
     rgen (0.8.2)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -56,8 +57,9 @@ PLATFORMS
 DEPENDENCIES
   bake-toolkit!
   coveralls
+  rake
   rspec
   simplecov
 
 BUNDLED WITH
-   1.15.0
+   1.15.1

--- a/bake-toolkit.gemspec
+++ b/bake-toolkit.gemspec
@@ -1,6 +1,5 @@
 $:.unshift(File.dirname(__FILE__)+"/")
 
-require "rake"
 require "lib/common/version"
 
 include FileUtils
@@ -8,7 +7,7 @@ include FileUtils
 #YAML::ENGINE.yamler = 'syck'
 
 PKG_VERSION = Bake::Version.number
-PKG_FILES = FileList[
+PKG_FILES = Dir[
   "lib/**/*.rb",
   "Rakefile.rb",
   "license.txt"
@@ -19,7 +18,7 @@ Gem::Specification.new do |s|
   s.version = PKG_VERSION
   s.summary = "Build tool to compile C/C++ projects fast and easy."
   s.description = "See documentation for more details"
-  s.files = PKG_FILES.to_a
+  s.files = PKG_FILES
   s.require_path = "lib"
   s.author = "Alexander Schaal"
   s.email = "alexander.schaal@esrlabs.com"
@@ -29,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency("highline", "=1.7.8")
   s.add_dependency("concurrent-ruby", "=1.0.5")
   s.add_dependency("colored", "=1.2")
+  s.add_development_dependency("rake")
   s.add_development_dependency("rspec")
   s.add_development_dependency("simplecov")
   s.add_development_dependency("coveralls")


### PR DESCRIPTION
Some developers prefer to use

    bundle install --path .vendor/bundle

To support this, bake-toolkit's Gemfile / GemSpec
- must actually activate Rake via Kernel#gem
- must not require Rake to be present already