### PR TITLE
Adapted compilation database to clang requirements

### DIFF
--- a/lib/bake/options/options.rb
+++ b/lib/bake/options/options.rb
@@ -148,7 +148,7 @@ module Bake
 
       add_option(["--version"                                    ], lambda {     Bake::Usage.version                     })
       add_option(["--list",               "--show_configs"       ], lambda {     @showConfigs = true                     })
-      add_option(["--compilation-db"                             ], lambda { |x,dummy| @cc2j_filename = (x ? x : "compilation-db.json" )})
+      add_option(["--compilation-db"                             ], lambda { |x,dummy| @cc2j_filename = (x ? x : "compile_commands.json" )})
       add_option(["--link-2-17",          "--link_2_17"          ], lambda {     @oldLinkOrder = true                    })
       add_option(["--build_",                                    ], lambda {     @buildDirDelimiter = "_"                })
 

--- a/lib/bake/options/usage.rb
+++ b/lib/bake/options/usage.rb
@@ -55,7 +55,7 @@ module Bake
       puts " --file-list              Writes all sources and headers used by a SINGLE config into '<config output folder>/file-list.txt'."
       puts "                          Writes all sources and headers used by ALL configs into '<main config output folder/global-file-list.txt'."
       puts " --prebuild               Does not build configs which are marked as 'prebuild', this feature is used for distributions."
-      puts " --compilation-db [<fn>]  Writes compilation information into filename fn in json format, default for fn is compilation-db.json"
+      puts " --compilation-db [<fn>]  Writes compilation information into filename fn in json format, default for fn is compile_commands.json"
       puts " --create exe|lib|custom  Creates a project with exe, lib or custom template"
       puts " --nb                     Suppresses the lines \"**** Building x of y: name (config) ****"
       puts " --crc32 <string>         Calulates the CRC32 of string (0x4C11DB7, init 0, final xor 0, input and result not reflected), used for Uid variable calculation"

--- a/lib/blocks/compile.rb
+++ b/lib/blocks/compile.rb
@@ -237,7 +237,7 @@ module Bake
 
         if Bake.options.cc2j_filename
           cmdJson = cmd.is_a?(Array) ? cmd.join(' ') : cmd
-          Blocks::CC2J << { :directory => @projectDir, :command => cmdJson, :file => source }
+          Blocks::CC2J << { :directory => @projectDir, :command => cmdJson, :file => File.join(@projectDir, source) }
         end
 
         if not (cmdLineCheck and BlockBase.isCmdLineEqual?(cmd, cmdLineFile))

--- a/spec/showinc_spec.rb
+++ b/spec/showinc_spec.rb
@@ -42,25 +42,6 @@ module Bake
       " ASM defines\n"+
       " done"
 
-def checkDb
-  f = File.read('compilation-db.json')
-     ar = JSON.parse(f)
-     expect(ar.length).to be == 3
-     ar.each do |a|
-       if a["file"] == "src/z.cpp"
-         expect(a["directory"].include?"spec/testdata/simple/lib").to be == true
-         expect(a["command"].include?"-c -MD -MF build/test_ok_main_test_ok/src/z.d -o build/test_ok_main_test_ok/src/z.o src/z.cpp").to be == true
-       elsif a["file"] == "src/y.cpp"
-         expect(a["directory"].include?"spec/testdata/simple/lib").to be == true
-         expect(a["command"].include?"-c -MD -MF build/test_ok_main_test_ok/src/y.d -o build/test_ok_main_test_ok/src/y.o src/y.cpp").to be == true
-       else
-         expect(a["file"]).to be == "src/x.cpp"
-         expect(a["directory"].include?"spec/testdata/simple/main").to be == true
-         expect(a["command"].include?"-c -MD -MF build/test_ok/src/x.d -o build/test_ok/src/x.o src/x.cpp").to be == true
-       end
-     end
-end
-
 describe "ShowInc" do
 
   it 'Default' do
@@ -96,19 +77,25 @@ describe "ShowInc" do
   end
 
   it 'compilation-db without parameter' do
+    def checkAbsoluteFilePath(cmd, fileName)
+      expect(cmd['file']).to be == "#{cmd['directory']}/src/#{fileName}"
+    end
+
     Bake.startBake("simple/main", ["test_ok", "--compilation-db"])
-    f = File.read('compilation-db.json')
+    f = File.read('compile_commands.json')
     ar = JSON.parse(f)
     expect(ar.length).to be == 3
     ar.each do |a|
-      if a["file"] == "src/z.cpp"
+      if File.basename(a["file"]) == "z.cpp"
+        checkAbsoluteFilePath(a, "z.cpp")
         expect(a["directory"].include?"spec/testdata/simple/lib").to be == true
         expect(a["command"].include?"-c -MD -MF build/test_ok_main_test_ok/src/z.d -o build/test_ok_main_test_ok/src/z.o src/z.cpp").to be == true
-      elsif a["file"] == "src/y.cpp"
+      elsif File.basename(a["file"]) == "y.cpp"
+        checkAbsoluteFilePath(a, "y.cpp")
         expect(a["directory"].include?"spec/testdata/simple/lib").to be == true
         expect(a["command"].include?"-c -MD -MF build/test_ok_main_test_ok/src/y.d -o build/test_ok_main_test_ok/src/y.o src/y.cpp").to be == true
       else
-        expect(a["file"]).to be == "src/x.cpp"
+        checkAbsoluteFilePath(a, "x.cpp")
         expect(a["directory"].include?"spec/testdata/simple/main").to be == true
         expect(a["command"].include?"-c -MD -MF build/test_ok/src/x.d -o build/test_ok/src/x.o src/x.cpp").to be == true
       end


### PR DESCRIPTION
Bake already has a feature of generating compilation database in json format (see description in [clang docs](https://clang.llvm.org/docs/JSONCompilationDatabase.html)) but the output was not 100% compliant with clang.

In "file" field bake is now putting absolute paths of source files. In the projects with nested source directories, "directory" shows the main project dir, while the rest of the path is passed with the file name.
Clang doesn't support having relative subdirectories in the "file" field, so in order to keep 'directory' and 'command' fields untouched, we need to switch to absolute file paths.

Also the default file name for compilation database has been changed to 'compile_commands.json' - this is the default name used by clang.

Unit tests have been adapted, including reducing code duplication.