### PR TITLE
Further improvements in generating compilation database

### DIFF
--- a/lib/blocks/compile.rb
+++ b/lib/blocks/compile.rb
@@ -237,7 +237,12 @@ module Bake
 
         if Bake.options.cc2j_filename
           cmdJson = cmd.is_a?(Array) ? cmd.join(' ') : cmd
-          Blocks::CC2J << { :directory => @projectDir, :command => cmdJson, :file => File.join(@projectDir, source) }
+          srcFilePath = source
+          if Bake.options.consoleOutput_fullnames
+            srcFilePath = File.join(@projectDir, srcFilePath)
+            cmdJson[source] = srcFilePath
+          end
+          Blocks::CC2J << { :directory => @projectDir, :command => cmdJson, :file => srcFilePath }
         end
 
         if not (cmdLineCheck and BlockBase.isCmdLineEqual?(cmd, cmdLineFile))

--- a/spec/showinc_spec.rb
+++ b/spec/showinc_spec.rb
@@ -77,28 +77,35 @@ describe "ShowInc" do
   end
 
   it 'compilation-db without parameter' do
-    def checkAbsoluteFilePath(cmd, fileName)
-      expect(cmd['file']).to be == "#{cmd['directory']}/src/#{fileName}"
-    end
-
     Bake.startBake("simple/main", ["test_ok", "--compilation-db"])
     f = File.read('compile_commands.json')
     ar = JSON.parse(f)
     expect(ar.length).to be == 3
     ar.each do |a|
-      if File.basename(a["file"]) == "z.cpp"
-        checkAbsoluteFilePath(a, "z.cpp")
+      case a['file']
+      when 'src/z.cpp'
         expect(a["directory"].include?"spec/testdata/simple/lib").to be == true
         expect(a["command"].include?"-c -MD -MF build/test_ok_main_test_ok/src/z.d -o build/test_ok_main_test_ok/src/z.o src/z.cpp").to be == true
-      elsif File.basename(a["file"]) == "y.cpp"
-        checkAbsoluteFilePath(a, "y.cpp")
+      when 'src/y.cpp'
         expect(a["directory"].include?"spec/testdata/simple/lib").to be == true
         expect(a["command"].include?"-c -MD -MF build/test_ok_main_test_ok/src/y.d -o build/test_ok_main_test_ok/src/y.o src/y.cpp").to be == true
       else
-        checkAbsoluteFilePath(a, "x.cpp")
+        expect(a['file']).to be == 'src/x.cpp'
         expect(a["directory"].include?"spec/testdata/simple/main").to be == true
         expect(a["command"].include?"-c -MD -MF build/test_ok/src/x.d -o build/test_ok/src/x.o src/x.cpp").to be == true
       end
+    end
+  end
+
+  it 'compilation-db without parameter, using absolute paths' do
+    Bake.startBake("simple/main", ["test_ok", "--compilation-db", "--abs-paths"])
+    f = File.read('compile_commands.json')
+    ar = JSON.parse(f)
+    expect(ar.length).to be == 3
+    ar.each do |cmd|
+      fileName = File.basename(cmd['file'])
+      expect(cmd['file']).to be == "#{cmd['directory']}/src/#{fileName}"
+      expect(cmd['command'].include?"#{cmd['directory']}/src/#{fileName}").to be == true
     end
   end
 


### PR DESCRIPTION
When --abs-paths option is used, compilation database will include
absolute source paths in the 'commands' and 'file' fields.
Otherwise paths will be relative to the project directory.