### PR TITLE
Fix bakery collections that reference a quoted project name

### DIFF
--- a/lib/bakery/toBake.rb
+++ b/lib/bakery/toBake.rb
@@ -45,7 +45,7 @@ module Bake
       next unless bp.proj
       contents = File.open(bp.proj, "r") {|io| io.read }
       contents.split("\n").each do |c|
-        res = c.match("\\s*(Library|Executable|Custom){1}Config\\s*(\\w*)")
+        res = c.match("\\s*(Library|Executable|Custom){1}Config\\s*\"?(\\w*)\"?")
         if res
           if res[2].match(bp.conf) != nil
             toBuild << BuildPattern.new(bp.proj, res[2], nil)

--- a/spec/bakery_spec.rb
+++ b/spec/bakery_spec.rb
@@ -104,6 +104,12 @@ describe "bake" do
     expect(str.include?("0 of 0 builds ok")).to be == true
   end
 
+  it 'collection ref to quoted project name' do
+    str = `ruby bin/bakery -m spec/testdata/root1/main -b Quoted -w spec/testdata/root1 -r --adapt nols`
+    puts str
+    expect(str.include?("1 of 1 builds ok")).to be == true
+  end
+
   it 'collection invalid ref' do
     str = `ruby bin/bakery -m spec/testdata/root1/main -b InvalidRef -w spec/testdata/root1 -w spec/testdata/root2 -r --adapt nols`
     puts str

--- a/spec/testdata/root1/main/Collection.meta
+++ b/spec/testdata/root1/main/Collection.meta
@@ -53,3 +53,7 @@ Collection InvalidRef {
 Collection Nothing {
   SubCollection Nothing
 }
+
+Collection Quoted {
+  Project main, config: quoted
+}

--- a/spec/testdata/root1/main/Project.meta
+++ b/spec/testdata/root1/main/Project.meta
@@ -40,4 +40,7 @@ Project {
     DefaultToolchain GCC
   }
 
+  CustomConfig "quoted" {
+    DefaultToolchain GCC
+  }
 }


### PR DESCRIPTION
Within a bakery collection a project config that has a quoted is found
by bakery when building it's internal command list. Quoted project
names are needed if the name contains special chars, e.g dashes:

ExecutableConfig "aarch64-linux-android", extends: default