### PR TITLE
Add generic bake args to collections per project

### DIFF
--- a/bin/bakery
+++ b/bin/bakery
@@ -109,7 +109,7 @@ module Bake
     p = File.dirname(bp.proj)
     pRel = File.rel_from_to_project(Dir.pwd, p, false)
     pRel = "." if pRel.empty?
-    cmd = (["-m", pRel, "-b", bp.conf] + passedParams)
+    cmd = (["-m", pRel, "-b", bp.conf] + bp.args.split + passedParams)
     cmdWithNum = "bakery #{currentRun} of #{maxRuns}: bake " + cmd.join(" ")
     puts "\n#{$stars}"
     Bake.formatter.printInfo(cmdWithNum)

--- a/documentation/changelog.rst
+++ b/documentation/changelog.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+    * Added: allow additional bake arguments specified per project in a bakery collection
+
 March 22, 2018 - bake-toolkit 2.44.1
     * Bugfix: in Adapt.meta "__MAIN__" in project now applies to *all* configs in the main project
     * Changed: "--compilation-db" now generates absolute paths if "--abs-paths" is set

--- a/documentation/tips_and_tricks/the_bakery.rst
+++ b/documentation/tips_and_tricks/the_bakery.rst
@@ -68,5 +68,8 @@ Example:
             Project Sub3, config: Debug
             SubCollection UnitTestLibsWithoutBsp
         }
+        Collection MainWithBakeArgs {
+            Project Main, config: Debug, args: "--adapt Debug --rebuild"
+        }
 
 

--- a/lib/bakery/buildPattern.rb
+++ b/lib/bakery/buildPattern.rb
@@ -1,10 +1,11 @@
 module Bake
 
   class BuildPattern
-    attr_reader :proj, :conf, :coll_p
-    def initialize(proj, conf, coll_p)
+    attr_reader :proj, :conf, :args, :coll_p
+    def initialize(proj, conf, args, coll_p)
       @proj = proj
       @conf = conf
+      @args = args
       @coll_p = coll_p
     end
     def getId

--- a/lib/bakery/model/metamodel.rb
+++ b/lib/bakery/model/metamodel.rb
@@ -19,6 +19,7 @@ module Bake
     class Project < ModelElement
       has_attr 'name', String, :defaultValueLiteral => ""
       has_attr 'config', String, :defaultValueLiteral => ""
+      has_attr 'args', String, :defaultValueLiteral => ""
     end
     class Exclude < ModelElement
       has_attr 'name', String, :defaultValueLiteral => ""

--- a/lib/bakery/toBake.rb
+++ b/lib/bakery/toBake.rb
@@ -32,10 +32,10 @@ module Bake
       col.project.each do |p|
         projs = Root.search_to_depth(root.dir,p.name + "/Project.meta", root.depth)
         if projs.length == 0
-          toBuildPattern << BuildPattern.new(nil, nil, p) # remember it for sorted info printout
+          toBuildPattern << BuildPattern.new(nil, nil, p.args, p) # remember it for sorted info printout
         end
         projs.each do |f|
-          toBuildPattern << BuildPattern.new(f, "^"+p.config.gsub("*","(\\w*)")+"$", p)
+          toBuildPattern << BuildPattern.new(f, "^"+p.config.gsub("*","(\\w*)")+"$", p.args, p)
         end
       end
     end
@@ -48,7 +48,7 @@ module Bake
         res = c.match("\\s*(Library|Executable|Custom){1}Config\\s*(\\w*)")
         if res
           if res[2].match(bp.conf) != nil
-            toBuild << BuildPattern.new(bp.proj, res[2], nil)
+            toBuild << BuildPattern.new(bp.proj, res[2], bp.args, nil)
             bp.coll_p.found
           end
         end

--- a/spec/bakery_spec.rb
+++ b/spec/bakery_spec.rb
@@ -122,6 +122,18 @@ describe "bake" do
     expect(str.include?("Argument for option --dot missing")).to be == true
   end
 
+  it 'collection project arg ok' do
+    str = `ruby bin/bakery -m spec/testdata/root1/main -b ProjectArgs -w spec/testdata/root1 -w spec/testdata/root2 --adapt nols`
+    puts str
+    expect(str.include?("Rebuilding done.")).to be == true
+  end
+
+  it 'collection project arg not ok' do
+    str = `ruby bin/bakery -m spec/testdata/root1/main -b ProjectInvalidArgs -w spec/testdata/root1 --adapt nols`
+    puts str
+    expect(str.include?("Argument for option --dot missing")).to be == true
+  end
+
   it 'recursive test 1' do
     str = `ruby bin/bakery -m spec/testdata/recursiveBakery/gaga gaga`
     puts str

--- a/spec/testdata/root1/main/Collection.meta
+++ b/spec/testdata/root1/main/Collection.meta
@@ -53,3 +53,11 @@ Collection InvalidRef {
 Collection Nothing {
   SubCollection Nothing
 }
+
+Collection ProjectArgs {
+  Project main, config: test, args: "--rebuild"
+}
+
+Collection ProjectInvalidArgs {
+  Project main, config: test, args: "--dot"
+}


### PR DESCRIPTION
Advanced bake configuration cannot go without adaptions. The adapt
feature make bake quite unusable when you have to remember all the
individual adapts and maybe even type them. This is the reason why
almost all bake users write wrapper like shell scripts or even rake
configurations in order to store the long bake invocations somewhere.
This patch add a option to bakery that is part of the bake toolkit that
allows to define bake arguments for a collection. Normally collections
are used to run multiple bake call, but with this extension a collection
may act as a wrapper that is "bake aware".