### PR TITLE
[bake-format] Add support for range formatting

### DIFF
--- a/bin/bake-format
+++ b/bin/bake-format
@@ -3,47 +3,28 @@
 $:.unshift(File.dirname(__FILE__)+"/../lib")
 
 require_relative '../lib/format/bake_format'
-begin
-  if ARGV.size == 2
-    indent = '  '
-    input = ARGV[0]
-    output = ARGV[1]
-  elsif ARGV.size == 3
-    indent = ARGV[0]
-    indent = indent.split('=')
-    raise 'indent must have =' unless indent.size == 2
-    raise 'indent must start with --indent' unless indent.first == '--indent'
-    indent = indent.last
-    input = ARGV[1]
-    output = ARGV[2]
-  else
-    raise 'cannot understand'
-  end
-rescue
-  puts [
-    "Usage: #{__FILE__} [--indent=string] input output",
-    "  --indent=string, indent defaults to two spaces.",
-    "    Note, you can escape a tab in bash by ctrl-vTAB with sourrounding \" e.g. \"--input=    \"",
-    "  input, filename or '-' for stdin",
-    "  output, filename, '-' for stdout, '--' for same as input file"
-  ].join("\n")
-  exit 1
-end
+require_relative '../lib/format/options/options'
+
+$options = Bake::BakeFormatOptions.new(ARGV)
+$options.parse_options()
 
 data =
-  if input == '-'
+  if $options.input == '-'
     STDIN.read
   else
-    File.read(input)
+    File.read($options.input)
   end
 
 out =
-  if output == '-'
+  if $options.output == '-'
     STDOUT
-  elsif output == '--'
-    out = input == STDIN ? STDOUT : File.open(input, 'w')
+  elsif $options.output == '--'
+    out = ($options.input == '-') ? STDOUT : File.open($options.input, 'w')
   else
-    File.open(output, 'w')
+    File.open($options.output, 'w')
   end
 
-bake_format(data, out, indent)
+start_line = $options.start_line || 0
+end_line = $options.end_line || data.lines.count
+
+bake_format(data, out, $options.indent, start_line, end_line)

--- a/lib/common/version.rb
+++ b/lib/common/version.rb
@@ -19,6 +19,10 @@ module Bake
     def self.printBakecleanVersion()
       printBakeVersion("clean")
     end
+
+    def self.printBakeFormatVersion()
+      printBakeVersion("-format")
+    end
   end
 
   expectedRGen = "0.8.2"

--- a/lib/format/bake_format.rb
+++ b/lib/format/bake_format.rb
@@ -1,7 +1,6 @@
-def bake_format(data, output, indent)
+def bake_format(data, output, indent, start_line, end_line)
   indent_level = 0
-  data.each_line do |l|
-    l.strip!
+  data.each_line.with_index do |l, index|
     opening = l.count('{')
     closing = l.count('}')
     old_indent_level = indent_level
@@ -13,7 +12,12 @@ def bake_format(data, output, indent)
       else
         indent * indent_level
       end
-    output.puts((prefix + l).rstrip)
+
+    if index.between?(start_line, end_line)
+      l = (prefix + l.strip)
+    end
+
+    output.puts(l)
   end
   output.close
 end

--- a/lib/format/options/options.rb
+++ b/lib/format/options/options.rb
@@ -1,0 +1,70 @@
+require_relative '../../common/options/parser'
+require_relative '../../common/version'
+
+module Bake
+
+  class BakeFormatOptions < Parser
+    attr_reader :indent, :input, :output # String
+    attr_reader :start_line, :end_line # Fixnum
+
+    def initialize(argv)
+      super(argv)
+
+      @input = '-'
+      @output = '-'
+      @start_line = nil
+      @end_line = nil
+      @indent = '  '
+      @index = 0
+
+      add_option([""             ], lambda { |x| collect_args(x)                                      })
+      add_option(["--indent"     ], lambda { |x| @indent = x                                          })
+      add_option(["--lines"      ], lambda { |x| set_lines(x)                                         })
+      add_option(["-h", "--help" ], lambda { usage; ExitHelper.exit(0)                                })
+      add_option(["--version"    ], lambda { Bake::Version.printBakeFormatVersion; ExitHelper.exit(0) })
+    end
+
+    def usage
+      puts [
+        "Usage: #{__FILE__} [--indent=string] [--lines=string] input output",
+        "  --indent=string, indent defaults to two spaces.",
+        "    Note, you can escape a tab in bash by ctrl-vTAB with sourrounding \" e.g. \"--input=    \"",
+        "  --lines=string, [start line]:[end line] - format a range of lines.",
+        "  input, filename or '-' for stdin",
+        "  output, filename, '-' for stdout, '--' for same as input file"
+      ].join("\n")
+    end
+
+    def parse_options()
+      parse_internal(true)
+    end
+
+  end
+
+end
+
+def collect_args(x)
+  if @index == 0
+    @input = x
+  elsif @index == 1
+    @output = x
+  elsif
+    Bake.formatter.printError("Error: wrong number of the arguments")
+    ExitHelper.exit(1)
+  end
+
+  @index += 1
+end
+
+def set_lines(lines)
+  m = lines.match(/(?<start_line>\d*):(?<end_line>\d*)/)
+
+  if m == nil
+    Bake.formatter.printError("Error: \"#{line}\" has invalid format")
+    ExitHelper.exit(1)
+  end
+
+  @start_line = m[:start_line].to_i
+  @end_line = m[:end_line].to_i
+
+end


### PR DESCRIPTION
Introduce new command line argument '--lines=[start_line]:[end_line]' to support IDE range formatting