### PR TITLE
Add CLANG_BITCODE toolchain

### DIFF
--- a/lib/bake/toolchain/clang_bitcode.rb
+++ b/lib/bake/toolchain/clang_bitcode.rb
@@ -1,0 +1,34 @@
+require_relative'../../common/utils'
+require_relative '../toolchain/provider'
+require_relative '../toolchain/errorparser/error_parser'
+require_relative '../toolchain/errorparser/gcc_compiler_error_parser'
+require_relative '../toolchain/errorparser/gcc_linker_error_parser'
+
+module Bake
+  module Toolchain
+    CLANG_BITCODE_CHAIN = Provider.add("CLANG_BITCODE")
+
+    CLANG_BITCODE_CHAIN[:COMPILER][:CPP].update({
+      :COMMAND => "clang++",
+      :DEFINE_FLAG => "-D",
+      :OBJECT_FILE_FLAG => "-o",
+      :OBJ_FLAG_SPACE => true,
+      :OBJECT_FILE_ENDING => ".bc",
+      :COMPILE_FLAGS => "-emit-llvm -c ",
+      :ERROR_PARSER => nil,
+      :DEP_FLAGS => "-MD -MF",
+      :DEP_FLAGS_SPACE => true,
+    })
+
+    CLANG_BITCODE_CHAIN[:COMPILER][:C] = Utils.deep_copy(CLANG_BITCODE_CHAIN[:COMPILER][:CPP])
+    CLANG_BITCODE_CHAIN[:COMPILER][:C][:SOURCE_FILE_ENDINGS] = Provider.default[:COMPILER][:C][:SOURCE_FILE_ENDINGS]
+    CLANG_BITCODE_CHAIN[:COMPILER][:C][:COMMAND] = "clang"
+
+    CLANG_BITCODE_CHAIN[:ARCHIVER][:COMMAND] = "llvm-link"
+    CLANG_BITCODE_CHAIN[:ARCHIVER][:ARCHIVE_FLAGS] = "-o"
+    CLANG_BITCODE_CHAIN[:ARCHIVER][:ARCHIVE_FILE_ENDING] = ".bc"
+
+    CLANG_BITCODE_CHAIN[:LINKER][:COMMAND] = "llvm-link"
+    CLANG_BITCODE_CHAIN[:LINKER][:EXE_FLAG] = "-o"
+  end
+end

--- a/lib/bake/toolchain/provider.rb
+++ b/lib/bake/toolchain/provider.rb
@@ -88,6 +88,7 @@ module Bake
           :PREFIX => "$(ArchiverPrefix)",
           :ARCHIVE_FLAGS => "",
           :ARCHIVE_FLAGS_SPACE => true,
+          :ARCHIVE_FILE_ENDING => ".a",
           :FLAGS => "",
           :ERROR_PARSER => nil,
           :FILE_COMMAND => ""
@@ -163,6 +164,7 @@ require_relative '../toolchain/diab'
 require_relative '../toolchain/gcc'
 require_relative '../toolchain/clang'
 require_relative '../toolchain/clang_analyze'
+require_relative '../toolchain/clang_bitcode'
 require_relative '../toolchain/ti'
 require_relative '../toolchain/greenhills'
 require_relative '../toolchain/keil'

--- a/lib/blocks/compile.rb
+++ b/lib/blocks/compile.rb
@@ -133,14 +133,18 @@ module Bake
         return false
       end
 
+      def calcObjectBasename(object)
+        File.basename(object, File.extname(object))
+      end
+
       def calcCmdlineFile(object)
-        File.expand_path(object[0..-3] + ".cmdline", @projectDir)
+        File.expand_path(calcObjectBasename(object) + ".cmdline", @projectDir)
       end
 
       def calcDepFile(object, type)
         dep_filename = nil
         if type != :ASM
-          dep_filename = object[0..-3] + ".d"
+          dep_filename = calcObjectBasename(object) + ".d"
         end
         dep_filename
       end

--- a/lib/blocks/compile.rb
+++ b/lib/blocks/compile.rb
@@ -134,7 +134,7 @@ module Bake
       end
 
       def calcObjectBasename(object)
-        File.basename(object, File.extname(object))
+        object.chomp(File.extname(object))
       end
 
       def calcCmdlineFile(object)

--- a/lib/blocks/library.rb
+++ b/lib/blocks/library.rb
@@ -18,10 +18,13 @@ module Bake
       end
 
       def calcArtifactName
+        archiver = @block.tcs[:ARCHIVER]
+        fileEnding = archiver[:ARCHIVE_FILE_ENDING]
+
         if not @config.artifactName.nil? and @config.artifactName.name != ""
           baseFilename = @config.artifactName.name
         else
-          baseFilename = "lib#{@projectName}.a"
+          baseFilename = "lib#{@projectName}#{fileEnding}"
         end
         if !@config.artifactExtension.nil? && @config.artifactExtension.name != "default"
           extension = ".#{@config.artifactExtension.name}"


### PR DESCRIPTION
Using clang with -emit-llvm option and llvm-link for linking, create
pure bitcode executables for analysis and whole program optimisation