### PR TITLE
Skip CompilationCheck on dry run

### DIFF
--- a/lib/tocxx.rb
+++ b/lib/tocxx.rb
@@ -859,6 +859,7 @@ module Bake
                !Bake.options.linkOnly &&
                !Bake.options.prepro &&
                !Bake.options.compileOnly &&
+               !Bake.options.dry &&
                !Bake.options.clean
 
               ccChecks = []


### PR DESCRIPTION
Bake crashes when --dry option is used because dependency files (.d) are
not generated.