### PR TITLE
Use llvm-lib to link when using clang on windows

### DIFF
--- a/lib/bake/toolchain/clang.rb
+++ b/lib/bake/toolchain/clang.rb
@@ -32,6 +32,9 @@ module Bake
     if Bake::Utils::OS::name == "Mac"
       CLANG_CHAIN[:ARCHIVER][:COMMAND] = "libtool"
       CLANG_CHAIN[:ARCHIVER][:ARCHIVE_FLAGS] = "-static -o"
+    elsif Bake::Utils::OS::name == "Windows"
+      CLANG_CHAIN[:ARCHIVER][:COMMAND] = "clang"
+      CLANG_CHAIN[:ARCHIVER][:ARCHIVE_FLAGS] = "-fuse-ld=llvm-lib -o"
     else
       CLANG_CHAIN[:ARCHIVER][:COMMAND] = "ar"
       CLANG_CHAIN[:ARCHIVER][:ARCHIVE_FLAGS] = "r"


### PR DESCRIPTION
Maybe this needs to be conditionned to another target, this will *not* use ar to link even for mingw environment.
Or maybe we could make the environment detection smarter...