### PR TITLE
Add ExcludeDir to bakery meta language

### DIFF
--- a/documentation/tips_and_tricks/the_bakery.rst
+++ b/documentation/tips_and_tricks/the_bakery.rst
@@ -50,6 +50,7 @@ Note: use hash marks (#) for comments.
     :ref:`collection` <name> {
       :ref:`Project <projectCollection>` <name>, config: <name>, args: <arguments>
       :ref:`exclude` <name>, config: <name>
+      :ref:`excludeDir` <name>
       :ref:`subCollection` <name>
     }
 
@@ -78,7 +79,16 @@ Exclude
 
 Specify the projects with it's configs to exclude from build. It is possible to use "*" as wildcards.
 
-*Mandatory: yes, quantity: 0..n, default: -*
+*Mandatory: no, quantity: 0..n, default: -*
+
+.. _excludeDir:
+
+ExcludeDir
+----------
+
+Specify the directory relative to the Collection.meta. All projects inside it will be excluded from the build.
+
+*Mandatory: no, quantity: 0..n, default: -*
 
 .. _subCollection:
 
@@ -100,6 +110,7 @@ Example of Collection.meta
     Collection UnitTestLibsWithoutBsp {
         Project "*", config: "UnitTestLib*"
         Exclude "bsp*", config: "*"
+        EcludeDir "path/to/some/folder"
     }
     Collection MySpecialCollection {
         Project Main1, config: Debug

--- a/lib/bakery/model/metamodel.rb
+++ b/lib/bakery/model/metamodel.rb
@@ -25,6 +25,10 @@ module Bake
       has_attr 'name', String, :defaultValueLiteral => ""
       has_attr 'config', String, :defaultValueLiteral => ""
     end
+
+    class ExcludeDir < ModelElement
+      has_attr 'name', String, :defaultValueLiteral => ""
+    end
     class SubCollection < ModelElement
       has_attr 'name', String, :defaultValueLiteral => ""
     end
@@ -32,6 +36,7 @@ module Bake
       has_attr 'name', String, :defaultValueLiteral => ""
       contains_many 'project', Project, 'collection'
       contains_many 'exclude', Exclude, 'collection'
+      contains_many 'exclude_dir', ExcludeDir, 'collection'
       contains_many 'collections', SubCollection, 'collection'
     end
 

--- a/lib/bakery/toBake.rb
+++ b/lib/bakery/toBake.rb
@@ -67,10 +67,17 @@ module Bake
       p.config = "^"+p.config.gsub("*","(\\w*)")+"$"
     end
 
+    col.exclude_dir.each do |e|
+      e.name = File.expand_path(e.name, @options.collection_dir)
+    end
+
     toBuild.delete_if do |bp|
       exclude = false
       col.exclude.each do |p|
         exclude = true if (bp.proj.match(p.name) != nil and bp.conf.match(p.config) != nil)
+      end
+      col.exclude_dir.each do |e|
+        exclude = true if bp.proj.start_with?(e.name)
       end
       exclude
     end

--- a/spec/bakery_spec.rb
+++ b/spec/bakery_spec.rb
@@ -34,7 +34,6 @@ describe "bakery" do
     str = `ruby bin/bakery -m spec/testdata/root1/main -b gigi --adapt nols`
     puts str
     expect(str.include?("0 of 0 builds ok")).to be == true
-
   end
 
   it 'collection working' do
@@ -177,6 +176,13 @@ describe "bakery" do
     expect(str.include?("collWarning/main/Collection.meta:9: Warning: pattern does not match any project: doesNotExist3")).to be == true
     expect(str.include?("collWarning/main/Collection.meta:10: Warning: pattern does not match any config: doesNotExist4")).to be == true
     expect(str.include?("4 of 4 builds ok")).to be == true
+  end
+
+  it 'collection exclude directory' do
+    str = `ruby bin/bakery -m spec/testdata/root1/main -b ExcludeDir --adapt nols`
+    puts str
+    expect(str.include?("lib1")).to be == true
+    expect(str.include?("1 of 1 builds ok")).to be == true
   end
 
 end

--- a/spec/testdata/root1/main/Collection.meta
+++ b/spec/testdata/root1/main/Collection.meta
@@ -68,3 +68,9 @@ Collection ProjectInvalidArgs {
 Collection Quoted {
   Project main, config: "quo-te:d"
 }
+
+Collection ExcludeDir {
+  Project "lib1", config: "test"
+  Project "lib3", config: "*"
+  ExcludeDir "../lib3"
+}


### PR DESCRIPTION
- add support of ExcludeDir with single `name` parameter.
It specifies which directories shall be excluded from the bakery build