### PR TITLE
Add support for arrays in CommandLine steps

### DIFF
--- a/lib/bake/model/metamodel.rb
+++ b/lib/bake/model/metamodel.rb
@@ -201,11 +201,14 @@ module Bake
         contains_many 'except', Except, 'parent'
       end
 
-      class Step < ModelElement
-        has_attr 'name', String, :defaultValueLiteral => ""
+      class StepBase < ModelElement
         has_attr 'echo', String, :defaultValueLiteral => "on"
         has_attr 'independent', Boolean, :defaultValueLiteral => "false"
         has_many_attr 'validExitCodes', Integer
+      end
+
+      class Step < StepBase
+        has_attr 'name', String, :defaultValueLiteral => ""
       end
 
       class Makefile < Step
@@ -238,27 +241,28 @@ module Bake
         has_attr 'name', String, :defaultValueLiteral => "0.0"
       end
 
-      class CommandLine < Step
+      class CommandLine < StepBase
+        has_many_attr 'name', String, :defaultValueLiteral => ""
       end
 
       class PreSteps < ModelElement
-        contains_many 'step', Step, 'parent'
+        contains_many 'step', StepBase, 'parent'
       end
 
       class PostSteps < ModelElement
-        contains_many 'step', Step, 'parent'
+        contains_many 'step', StepBase, 'parent'
       end
 
       class ExitSteps < ModelElement
-        contains_many 'step', Step, 'parent'
+        contains_many 'step', StepBase, 'parent'
       end
 
       class CleanSteps < ModelElement
-        contains_many 'step', Step, 'parent'
+        contains_many 'step', StepBase, 'parent'
       end
 
       class StartupSteps < ModelElement
-        contains_many 'step', Step, 'parent'
+        contains_many 'step', StepBase, 'parent'
       end
 
       class LinkerScript < ModelElement
@@ -348,7 +352,7 @@ module Bake
       end
 
       class CustomConfig < BaseConfig_INTERNAL
-        contains_one 'step', Step, 'parent'
+        contains_one 'step', StepBase, 'parent'
         module ClassModule
           def color
             "red"

--- a/lib/bake/subst.rb
+++ b/lib/bake/subst.rb
@@ -374,8 +374,14 @@ module Bake
         return if Metamodel::DefaultToolchain === elem
         return if Metamodel::Toolchain === elem.class
         next if a.eType.name != "EString"
-        substStr = substString(elem.getGeneric(a.name), elem, a.name)
-        elem.setGeneric(a.name, substStr)
+        value = elem.getGeneric(a.name)
+        if value.kind_of?(Array)
+          substArr = value.map { |s| substString(s, elem, a.name) }
+          elem.setGeneric(a.name, substArr)
+        else
+          substStr = substString(value, elem, a.name)
+          elem.setGeneric(a.name, substStr)
+        end
       end
 
       childsRefs = elem.class.ecore.eAllReferences.select{|r| r.containment}

--- a/lib/blocks/commandLine.rb
+++ b/lib/blocks/commandLine.rb
@@ -8,7 +8,7 @@ module Bake
 
       def initialize(config)
         @config = config # Bake::Metamodel::CommandLine
-        @commandLine = config.name
+        @commandLine = config.name.kind_of?(Array) ? config.name.join(' ') : config.name
         @projectDir = config.get_project_dir
       end
 

--- a/spec/array_spec.rb
+++ b/spec/array_spec.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'helper'
+
+require 'common/version'
+
+require 'bake/options/options'
+require 'common/exit_helper'
+require 'fileutils'
+
+module Bake
+  describe 'Array' do
+    it 'execute command passed as array' do
+      Bake.startBake('steps/main', ['test3'])
+      expect($mystring.include?('COMMAND1')).to be == true
+    end
+  end
+end

--- a/spec/testdata/steps/main/Project.meta
+++ b/spec/testdata/steps/main/Project.meta
@@ -26,4 +26,12 @@ Project {
     DefaultToolchain GCC
   }
 
+  CustomConfig test3 {
+    PostSteps {
+      CommandLine ["echo", "COMMAND1"], echo: off
+    }
+
+    DefaultToolchain GCC
+  }
+
 }


### PR DESCRIPTION
Long commands can be split over multiple lines with arrays